### PR TITLE
Add variable value to passwords argument

### DIFF
--- a/pypi-server/templates/statefulset.yaml
+++ b/pypi-server/templates/statefulset.yaml
@@ -39,7 +39,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["pypi-server"]
           args:
-            - --passwords=/config/passwords
+            - --passwords={{ .Values.auth.passwords | default ("/config/passwords") }}
             - --authenticate={{ .Values.auth.actions }}
             - --port=8080
             {{- range .Values.server.extraArgs }}

--- a/pypi-server/values.yaml
+++ b/pypi-server/values.yaml
@@ -57,6 +57,9 @@ auth:
   ## Use '.' or '' for empty. Requires to have set the password (option below).
   ## Available actions are update, download and list
   actions: list,download,update
+  ## Path to password file for authentication
+  ## If `actions` has been set to empty, you must also uncomment this
+  # passwords: '.'
   ## Map of username / encoded passwords that will be put to the htpasswd file
   ## use `htpasswd -n -b username password` to generate them
   credentials: {


### PR DESCRIPTION
First off, thanks for a great helm chart. I made this proposed change because I had issues starting the server without any auth options enabled, and I had to go in and modify the statefulset file. With this change, that shouldn't be necessary any more. If the value is left unassigned, it uses the original default, but uncommenting it and assigning it makes it work along with the empty `actions` variable.

Feel free to make comments or changes if needed.